### PR TITLE
Fix requirements and python versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,11 @@ The project is build with ``apiflask``
 https://apiflask.com/
 ```
 
+Python version: 3.11
+
 Install all deps
 ```
+pip install -U pip wheel
 pip install -r requirements.txt
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ APIFlask==1.3.0
 apispec==6.3.0
 APScheduler==3.10.1
 attrs==22.2.0
-backports.zoneinfo==0.2.1
+backports.zoneinfo==0.2.1;python_version<"3.9"
 certifi==2022.12.7
 charset-normalizer==3.1.0
 click==8.1.3


### PR DESCRIPTION
Fix requirements for Python 3.11 and update README with this information.

```
Failed to build backports.zoneinfo
ERROR: Could not build wheels for backports.zoneinfo, which is required to install pyproject.toml-based projects
```